### PR TITLE
[fix] the 🔍 magnifier emoji malposition

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ exports.decorateConfig = config =>
       position: absolute;
       content: "🔍";
       font-size: 10px;
-      margin: 7px;
+      margin: 0 0 0 7px;
       z-index: 999;
     }
     #hyper-search-input {


### PR DESCRIPTION
`hyper version 3.0.2`

Problem found [here](https://github.com/jaanauati/hyper-search/issues/80)

I don't know why this strange occurred but I tried to fix it by modifying the margin and it looks.. okay

### Before
![image](https://user-images.githubusercontent.com/15688641/102120484-91083380-3e7d-11eb-9d25-49b9de6091ad.png)


### After
![image](https://user-images.githubusercontent.com/15688641/102120600-bf860e80-3e7d-11eb-84d6-57afad8c5f8f.png)
